### PR TITLE
Remove dangling commas from hookDefineRoutes

### DIFF
--- a/TimelinePlugin.php
+++ b/TimelinePlugin.php
@@ -143,7 +143,7 @@ class TimelinePlugin extends Omeka_Plugin_AbstractPlugin
             array(
                 'module'        => 'timeline',
                 'controller'    => 'timelines'
-                ),
+                )
             );
         $router->addRoute('timelinesDefault', $defaultRoute);
 
@@ -152,7 +152,7 @@ class TimelinePlugin extends Omeka_Plugin_AbstractPlugin
                 'module'        => 'timeline',
                 'controller'    => 'timelines',
                 'action'        => 'browse'
-                ),
+                )
             );
         $router->addRoute('timelinesRedirect', $redirectRoute);
 


### PR DESCRIPTION
This prevents the plugin from crashing the plugins admin screen when Omeka runs on PHP 7.x.