### PR TITLE
Remove Exhibit Builder dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Timeline
-Create [TimelineJS](https://timeline.knightlab.com) timelines accessible via ExhibitBuilder blocks or shortcode.
+Create [TimelineJS](https://timeline.knightlab.com) timelines, accessible via standalone pages, ExhibitBuilder blocks, and shortcode. 
 
 Based off the archived [Neatline Time plugin](https://omeka.org/classic/plugins/NeatlineTime/).
 
 ## Installation
 
 Install in the usual Omeka way.
+
+## Documentation
+See [User Guide](https://omeka.org/classic/docs/Plugins/Timeline/).

--- a/plugin.ini
+++ b/plugin.ini
@@ -1,11 +1,10 @@
 [info]
 name="Timeline"
 author="Omeka Team"
-description="Adds a TimelineJS block to ExhibitBuilder"
+description="Create TimelineJS timelines with optional ExhibitBuilder integration."
 version="2.2"
 support_link="https://forum.omeka.org/c/omeka-classic/plugins"
 link="https://omeka.org/classic/docs/Plugins/Timeline/"
 omeka_minimum_version="3.2"
 omeka_target_version="3.2"
 license="GPLv3"
-required_plugins="ExhibitBuilder"


### PR DESCRIPTION
It looks like this plugin works perfectly well without the Exhibit Builder plugin as a dependency. Timelines can be created, browsed, and viewed independent of Exhibit Builder. This PR just removes the dependency and updates the relevant plugin descriptions.